### PR TITLE
Fix build failure from lack of <cstdint> headers

### DIFF
--- a/src/PommeDebug.h
+++ b/src/PommeDebug.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <sstream>
+#include <cstdint>
 
 #define POMME_DEBUG_MEMORY		false
 #define POMME_DEBUG_SOUND		false

--- a/src/Utilities/bigendianstreams.cpp
+++ b/src/Utilities/bigendianstreams.cpp
@@ -1,5 +1,6 @@
 #include "Utilities/bigendianstreams.h"
 #include "Utilities/IEEEExtended.h"
+#include <cstdint>
 
 Pomme::StreamPosGuard::StreamPosGuard(std::istream& theStream) :
 	stream(theStream)


### PR DESCRIPTION
After trying to compile [Nanosaur 2](https://github.com/jorio/Nanosaur2) on my Arch Linux computer, the build fails. The log shows these relevant lines:

```
/home/patrick/aur/nanosaur2/src/nanosaur2/extern/Pomme/src/PommeDebug.h:7:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    6 | #include <sstream>
  +++ |+#include <cstdint>
    7 | 
```
```
/home/patrick/aur/nanosaur2/src/nanosaur2/extern/Pomme/src/Utilities/bigendianstreams.cpp:3:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    2 | #include "Utilities/IEEEExtended.h"
  +++ |+#include <cstdint>
    3 | 
```

After adding the line `#include <cstdint>` to `PommeDebug.h` and `bigendianstreams.cpp`, the build works and runs normally as expected. I've double checked this with [Bugdom](https://github.com/jorio/Bugdom), [Billy Frontier](https://github.com/jorio/BillyFrontier) and [Mighty Mike](https://github.com/jorio/MightyMike).