### PR TITLE
Include cstring header

### DIFF
--- a/src/Input/SDLInput.cpp
+++ b/src/Input/SDLInput.cpp
@@ -5,6 +5,7 @@
 
 #include <SDL_events.h>
 #include <SDL_keyboard.h>
+#include <cstring>
 
 //-----------------------------------------------------------------------------
 // Input


### PR DESCRIPTION
If the POMME_NO_INPUT flag is unset, the build will fail without including this header.